### PR TITLE
Add American Twine to "/lunch"

### DIFF
--- a/commands/lunch.rb
+++ b/commands/lunch.rb
@@ -6,7 +6,7 @@ class Lunch < BaseCommand
     specials << ''
     specials << squeaky_beaker
     specials << ''
-    specials << hubspot
+    specials << fooda
     specials << '```'
 
     respond specials.join("\n")
@@ -44,7 +44,7 @@ class Lunch < BaseCommand
     specials.flatten
   end
 
-  def hubspot
+  def fooda
     agent = Mechanize.new
     page = agent.get('https://app.fooda.com/login')
 
@@ -62,18 +62,19 @@ class Lunch < BaseCommand
 
     parser = page.parser
 
-    day_of_week = parser.search("a.cal__day--active").search("div.cal__day__inner__info__label").text
-    response = "Hubspot/Davenport lunch vendors for #{day_of_week}:\n"
+    response = "FOODA\n"
 
-    vendors = parser.search("a.js-vendor-tile")
-    vendors.each do |vendor|
-      vendor_name = vendor.search("div.myfooda-event__name").text
-      vendor_cuisine = vendor.search("div.myfooda-event__cuisine").text
-      vendor_url = vendor.attributes["href"].value
+    page.links_with(:text => /Lunch at/).each do |link|
+      agent.get(link.href)
+      response += "*#{link.text.split(",")[0]}*\n\n"
 
-      response += "\n"
-      response += "#{vendor_name} (#{vendor_cuisine})\n"
-      response += "#{vendor_url}\n"
+      vendors = agent.page.parser.search("a.js-vendor-tile")
+      vendors.each do |vendor|
+        response += "#{vendor.search("div.myfooda-event__name").text.lstrip}"
+        response += " | #{vendor.search("div.myfooda-event__cuisine").text.lstrip}\n"
+        response += vendor.attributes["href"].value
+        response += "\n\n"
+      end
     end
     response
   end

--- a/commands/lunch.rb
+++ b/commands/lunch.rb
@@ -39,7 +39,7 @@ class Lunch < BaseCommand
 
     specials.push('SQUEAKY BEAKER')
     specials << food_soups.map(&:text).reject! do |ele|
-      /(- \d+\.\d+ -|Soup)/ === ele
+      /(- \d+\.\d+ -|Soup)/ === ele || ele.blank?
     end
     specials.flatten
   end


### PR DESCRIPTION
Notes:
* We will have to add the American Twine Building to our Fooda account once this is merged.
* We should take time to refactor/test `Lunch#fooda` due to it's length and complexity. I wanted to get this up and running so people knew their lunch options but I plan to submit a follow-up refactoring PR in the near future.
* I also removed the extra whitespace from the Squeaky response because it was causing weird formatting issues.